### PR TITLE
Made: Source path for certificates and chains configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,7 +22,14 @@ apache_site_disable:
 apache_site_enable:
   - test.conf
 
+# Local paths:
+# - Storing *.key files
 apache_ssl_key_store: "/root/csr"
+
+# - Storing certificate and chain files
+apache_ssl_certificates_store: "site_files/certificates"
+
+# Path where certificates will be stored at server
 apache_ssl_path: "/etc/apache2/ssl"
 
 apache_vhosts:

--- a/tasks/vhost.yml
+++ b/tasks/vhost.yml
@@ -37,7 +37,7 @@
 
 - name: Copy certificate
   copy:
-    src: "site_files/certificates/{{item.1.certificate_file}}"
+    src: "{{ apache_ssl_certificates_store }}/{{item.1.certificate_file}}"
     dest: "{{apache_ssl_path}}"
     mode: 0600
   notify: Restart apache
@@ -48,7 +48,7 @@
 
 - name: Copy chain certificate if present
   copy:
-    src: "site_files/certificates/{{item.1.chain_file}}"
+    src: "{{ apache_ssl_certificates_store }}/{{item.1.chain_file}}"
     dest: "{{apache_ssl_path}}"
     mode: 0600
   notify: Restart apache


### PR DESCRIPTION
Hi.
- Improved comments at `defaults/main.yml`
- Added new variable `apache_ssl_certificates_store` allowing configure certificate and chain files store location (before it was hard-coded)
